### PR TITLE
Automated repair through risk intelligence platform in 2023-06-27 15:12:36

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,14 @@
 	<dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>2.8.9</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-core</artifactId>
-                <version>2.8.2</version>
+                <version>2.15.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
修改组件依赖:   
pom.xml中修改dependency将org.apache.logging.log4j:log4j-core的版本由2.8.2修改为2.15.0.   
修改组件依赖:   
pom.xml中新增dependency:com.google.code.gson:gson:2.8.9.   

本功能是自动修复漏洞功能，需要人工确认修复是否正确。